### PR TITLE
v2.0.2: Fix Device model to match API response fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scadable"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
     { name = "Scadable" },
 ]

--- a/scadable/__init__.py
+++ b/scadable/__init__.py
@@ -41,4 +41,4 @@ __all__ = [
     "TelemetryEvent",
 ]
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/scadable/_models/_gateway.py
+++ b/scadable/_models/_gateway.py
@@ -7,12 +7,15 @@ from ._base import ScadableModel
 
 
 class Device(ScadableModel):
-    id: str
+    device_id: str | None = None
+    id: str | None = None
     name: str | None = None
     status: str | None = None
     protocol: str | None = None
+    connected: bool | None = None
     gateway_id: str | None = None
     last_seen_at: datetime | None = None
+    last_error: str | None = None
 
 
 class Gateway(ScadableModel):


### PR DESCRIPTION
API returns device_id, connected, last_error from GatewayDeviceInfo proto. Made id optional, added device_id, connected, last_error fields. 37 tests, 100% coverage.